### PR TITLE
Misc fcitx5 fix

### DIFF
--- a/fcitx5-addon.conf
+++ b/fcitx5-addon.conf
@@ -7,5 +7,5 @@ Type=SharedLibrary
 OnDemand=False
 Configurable=True
 
-[Addon/Dependencies]
-0=core
+[Addon/OptionalDependencies]
+0=wayland

--- a/src/Fcitx5ImEmojiPickerModule.hpp
+++ b/src/Fcitx5ImEmojiPickerModule.hpp
@@ -7,7 +7,7 @@
 #include <fcitx/addonmanager.h>
 #include <fcitx/instance.h>
 
-FCITX_CONFIGURATION(Fcitx5ImEmojiPickerModuleConfig, fcitx::KeyListOption triggerKey{this, "TriggerKey", "Trigger Key", {fcitx::Key("Control+Alt+Shift+period")}, fcitx::KeyListConstrain()};);
+FCITX_CONFIGURATION(Fcitx5ImEmojiPickerModuleConfig, fcitx::KeyListOption triggerKey{this, "TriggerKey", "Trigger Key", {fcitx::Key("Control+Alt+period")}, fcitx::KeyListConstrain()};);
 
 class Fcitx5ImEmojiPickerModule : public fcitx::AddonInstance {
 public:


### PR DESCRIPTION
1. fcitx::Key returned from keyEvent.key() is "normalized". The shift modifier is usually removed for simplicity to have uniformed key for different layout. If the keysym is a symbol, simply remove "shift" will also work.
2. WAYLAND_SOCKET may be unset by the qt thread. using an optional dependency (this ensures the loading order) on wayland to avoid it prevent waylandim from working.
3. Dependency on core is not required. core means the core library. It's only useful if you require a certain version of fcitx (e.g. core:5.0.10) to avoid lower version of fcitx accidentally load an incompatible addon.