### PR TITLE
fix crash if screen is null

### DIFF
--- a/src/EmojiPickerWindow.cpp
+++ b/src/EmojiPickerWindow.cpp
@@ -39,7 +39,12 @@ QPoint createPointInScreen(QWidget* window, QRect newPoint) {
   QRect windowRect = window->geometry();
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-  QRect screenRect = QApplication::screenAt(result)->geometry();
+  QScreen* screen = QApplication::screenAt(result);
+  if (!screen) {
+    return result;
+  }
+  
+  QRect screenRect = screen->geometry();
 #else
   QRect screenRect = QApplication::desktop()->availableGeometry(result);
 #endif


### PR DESCRIPTION
fixes #6

sidenote: if screen turns out to be null, automatic relocation of emoji picker window will not work.